### PR TITLE
Parsing hang fix

### DIFF
--- a/jupyter_forward/core.py
+++ b/jupyter_forward/core.py
@@ -128,7 +128,9 @@ class RemoteRunner:
             command = f'''{self.shell} -c "{command}"'''
         else:
             command = f'''{self.shell} -lc "{command}"'''
-        out = self.session.run(command, warn=warn, pty=pty, echo=echo, asynchronous=asynchronous, **kwargs)
+        out = self.session.run(
+            command, warn=warn, pty=pty, echo=echo, asynchronous=asynchronous, **kwargs
+        )
         if not asynchronous and exit and out.failed:
             sys.exit(1)
         return out

--- a/jupyter_forward/core.py
+++ b/jupyter_forward/core.py
@@ -120,16 +120,16 @@ class RemoteRunner:
         exit=True,
         warn=True,
         pty=True,
-        hide=None,
         echo=True,
+        asynchronous=False,
         **kwargs,
     ):
         if 'csh' in self.shell:
             command = f'''{self.shell} -c "{command}"'''
         else:
             command = f'''{self.shell} -lc "{command}"'''
-        out = self.session.run(command, warn=warn, pty=pty, hide=hide, echo=echo, **kwargs)
-        if out.failed and exit:
+        out = self.session.run(command, warn=warn, pty=pty, echo=echo, asynchronous=asynchronous, **kwargs)
+        if not asynchronous and exit and out.failed:
             sys.exit(1)
         return out
 

--- a/jupyter_forward/core.py
+++ b/jupyter_forward/core.py
@@ -195,7 +195,7 @@ class RemoteRunner:
             command = f'{self.launch_command} {self._prepare_batch_job_script(command)}'
 
         console.rule('[bold green]Launching Jupyter Lab', characters='*')
-        self.session.run(f'{self.shell} -c "{command}"', asynchronous=True, pty=True, echo=True)
+        self.run_command(command, asynchronous=True)
         self.parsed_result = self._parse_log_file()
 
         if self.port_forwarding:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -92,9 +92,12 @@ def test_connection(runner):
 
 @requires_ssh
 @pytest.mark.parametrize('command', ['echo $HOME'])
+@pytest.mark.parametrize('kwargs', [{}, dict(asynchronous=True)])
 @pytest.mark.parametrize('runner', SHELLS, indirect=True)
-def test_run_command(runner, command):
-    out = runner.run_command(command)
+def test_run_command(runner, command, kwargs):
+    out = runner.run_command(command, **kwargs)
+    if kwargs.get('asynchronous', False):
+        out = out.join()
     assert not out.failed
     f"{os.environ['HOME']}" in out.stdout.strip()
 


### PR DESCRIPTION
<!-- Thanks for submitting a PR, your contribution is really appreciated! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

## Change Summary

This PR fixes the problem referenced in #148, and it includes a mild refactor.  This PR changes the `run_command` method to accept an `asynchronous` argument and skip error checking / early exit when `True`.  Then, to assure that the arguments to the `self.shell` part of the remote command are correct (i.e., uses `-lc` when not using csh-style shells), the call to remotely launch Jupyter Lab is sent using `run_command`, to be consistent with all other remote commands used throughout Jupyter Forward.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

Closes #148 

## Checklist

- [x] Unit tests for the changes exist
- [x] Tests pass on CI
- [X] Documentation reflects the changes where applicable

It is my belief that this change is internal and doesn't need additional documentation.

A test of the `run_command` method should be added to test the `asynchronous` argument.