### PR TITLE
transfer files using a separate `paramiko` channel

### DIFF
--- a/jupyter_forward/core.py
+++ b/jupyter_forward/core.py
@@ -122,7 +122,7 @@ class RemoteRunner:
     def put_file(self, remote_path, content):
         client = self.session.client
         with client.get_transport().open_channel(kind='session') as channel:
-            channel.exec_command(f'sh -c "cat > {remote_path}"')
+            channel.exec_command(f'cat > {remote_path}')
             channel.sendall(content.encode())
 
     def run_command(

--- a/jupyter_forward/core.py
+++ b/jupyter_forward/core.py
@@ -259,6 +259,8 @@ class RemoteRunner:
         return parse_stdout(stdout)
 
     def _prepare_batch_job_script(self, command):
+        from rich.syntax import Syntax
+
         console.rule('[bold green]Preparing Batch Job script', characters='*')
         script_file = f'{self.log_dir}/batch_job_script_{timestamp}'
         shell = self.shell
@@ -271,6 +273,7 @@ class RemoteRunner:
             {command}
             """
         )
+        console.print(Syntax(script, "bash", line_numbers=True))
         self.put_file(script_file, script)
         self.run_command(f"chmod +x {script_file}", exit=True)
         console.print(f'[bold cyan]:white_check_mark: Batch Job script resides in {script_file}')

--- a/jupyter_forward/core.py
+++ b/jupyter_forward/core.py
@@ -189,7 +189,7 @@ class RemoteRunner:
 
     def _get_hostname(self):
         if self.launch_command:
-            return r'$(hostname -f)'
+            return '$(hostname -f)'
         else:
             return self.session.run('hostname -f').stdout.strip()
 

--- a/jupyter_forward/core.py
+++ b/jupyter_forward/core.py
@@ -115,7 +115,8 @@ class RemoteRunner:
         console.print(f'[bold cyan]:white_check_mark: Using shell: {self.shell}')
 
     def put_file(self, remote_path, content):
-        with self.session.get_transport().open_channel(kind="session") as channel:
+        client = self.session.client
+        with client.get_transport().open_channel(kind="session") as channel:
             channel.exec_command(f"cat > {remote_path}")
             channel.sendall(content.encode())
 

--- a/jupyter_forward/core.py
+++ b/jupyter_forward/core.py
@@ -117,8 +117,8 @@ class RemoteRunner:
 
     def put_file(self, remote_path, content):
         client = self.session.client
-        with client.get_transport().open_channel(kind="session") as channel:
-            channel.exec_command(f"cat > {remote_path}")
+        with client.get_transport().open_channel(kind='session') as channel:
+            channel.exec_command(f'cat > {remote_path}')
             channel.sendall(content.encode())
 
     def run_command(
@@ -273,9 +273,9 @@ class RemoteRunner:
             {command}
             """
         )
-        console.print(Syntax(script, "bash", line_numbers=True))
+        console.print(Syntax(script, 'bash', line_numbers=True))
         self.put_file(script_file, script)
-        self.run_command(f"chmod +x {script_file}", exit=True)
+        self.run_command(f'chmod +x {script_file}', exit=True)
         console.print(f'[bold cyan]:white_check_mark: Batch Job script resides in {script_file}')
         return script_file
 

--- a/jupyter_forward/core.py
+++ b/jupyter_forward/core.py
@@ -114,6 +114,11 @@ class RemoteRunner:
             self.shell = self.run_command(f'which {self.shell}').stdout.strip()
         console.print(f'[bold cyan]:white_check_mark: Using shell: {self.shell}')
 
+    def put_file(self, remote_path, content):
+        with self.session.get_transport().open_channel(kind="session") as channel:
+            channel.exec_command(f"cat > {remote_path}")
+            channel.sendall(content.encode())
+
     def run_command(
         self,
         command,

--- a/jupyter_forward/core.py
+++ b/jupyter_forward/core.py
@@ -122,7 +122,7 @@ class RemoteRunner:
     def put_file(self, remote_path, content):
         client = self.session.client
         with client.get_transport().open_channel(kind='session') as channel:
-            channel.exec_command(f'cat > {remote_path}')
+            channel.exec_command(f'sh -c "cat > {remote_path}"')
             channel.sendall(content.encode())
 
     def run_command(

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -113,6 +113,17 @@ def test_run_command_failure(runner, command):
     with pytest.raises(SystemExit):
         runner.run_command(command)
 
+@requires_ssh
+@pytest.mark.parametrize('content', ['echo $HOME', 'echo $(hostname -f)'])
+@pytest.mark.parametrize('runner', SHELLS, indirect=True)
+def test_put_file(runner, content):
+    path = '/.jupyter_forward/test_file'
+    runner.put_file(path, content)
+
+    out = runner.run_command(f'cat {path}')
+    assert content == out
+
+
 
 @requires_ssh
 @pytest.mark.parametrize('runner', SHELLS, indirect=True)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -135,7 +135,7 @@ def test_run_command_failure(runner, command):
 
 @requires_ssh
 @pytest.mark.parametrize('content', ['echo $HOME', 'echo $(hostname -f)'])
-@pytest.mark.parametrize('runner', ['bash'], indirect=True)
+@pytest.mark.parametrize('runner', [None], indirect=True)
 def test_put_file(runner, content):
     with tempfile(runner.session) as path:
         runner.put_file(path, content)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -16,9 +16,11 @@ ON_GITHUB_ACTIONS = os.environ.get('GITHUB_ACTIONS') is not None
 
 
 @contextmanager
-def delete_file(session, path):
+def tempfile(session):
+    out = session.run('mktemp')
+    path = out.stdout
     try:
-        yield
+        yield path
     finally:
         session.run(f'rm {path}')
 
@@ -141,7 +143,7 @@ def test_run_command_failure(runner, command):
 def test_put_file(runner, content):
     runner._set_log_directory()
     path = f'{runner.log_dir}/test_file'
-    with delete_file(runner.session, path):
+    with tempfile(runner.session) as path:
         runner.put_file(path, content)
 
         out = runner.run_command(f'cat {path}')

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -72,6 +72,8 @@ def test_runner_init_notebook_dir_error():
             f"{os.environ['JUPYTER_FORWARD_SSH_TEST_USER']}@{os.environ['JUPYTER_FORWARD_SSH_TEST_HOSTNAME']}",
             notebook_dir='~/notebooks/',
             notebook='~/my_notebook.ipynb',
+            auth_handler=lambda t, i, p: ['Loremipsumdolorsitamet'] * len(p),
+            fallback_auth_handler=lambda: 'Loremipsumdolorsitamet',
         )
 
 
@@ -81,6 +83,8 @@ def test_runner_init_port_unavailable():
         jupyter_forward.RemoteRunner(
             f"{os.environ['JUPYTER_FORWARD_SSH_TEST_USER']}@{os.environ['JUPYTER_FORWARD_SSH_TEST_HOSTNAME']}",
             port=22,
+            auth_handler=lambda t, i, p: ['Loremipsumdolorsitamet'] * len(p),
+            fallback_auth_handler=lambda: 'Loremipsumdolorsitamet',
         )
 
 
@@ -89,6 +93,8 @@ def test_runner_authentication_error():
     with pytest.raises(SystemExit):
         jupyter_forward.RemoteRunner(
             f"foobar@{os.environ['JUPYTER_FORWARD_SSH_TEST_HOSTNAME']}",
+            auth_handler=lambda t, i, p: ['Loremipsumdolorsitamet'] * len(p),
+            fallback_auth_handler=lambda: 'Loremipsumdolorsitamet',
         )
 
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -135,7 +135,7 @@ def test_run_command_failure(runner, command):
 
 @requires_ssh
 @pytest.mark.parametrize('content', ['echo $HOME', 'echo $(hostname -f)'])
-@pytest.mark.parametrize('runner', SHELLS, indirect=True)
+@pytest.mark.parametrize('runner', ['bash'], indirect=True)
 def test_put_file(runner, content):
     with tempfile(runner.session) as path:
         runner.put_file(path, content)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -118,11 +118,12 @@ def test_run_command_failure(runner, command):
 @pytest.mark.parametrize('content', ['echo $HOME', 'echo $(hostname -f)'])
 @pytest.mark.parametrize('runner', SHELLS, indirect=True)
 def test_put_file(runner, content):
-    path = '/.jupyter_forward/test_file'
+    runner._set_log_directory()
+    path = f'{runner.log_dir}/test_file'
     runner.put_file(path, content)
 
     out = runner.run_command(f'cat {path}')
-    assert content == out
+    assert content == out.stdout
 
 
 @requires_ssh

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -25,13 +25,21 @@ def tempfile(session):
         session.run(f'rm {path}')
 
 
+def dummy_auth_handler(title, instructions, prompt_list):
+    return ['Loremipsumdolorsitamet'] * len(prompt_list)
+
+
+def dummy_fallback_auth_handler():
+    return 'Loremipsumdolorsitamet'
+
+
 @pytest.fixture(scope='package')
 def runner(request):
     remote = jupyter_forward.RemoteRunner(
         f"{os.environ['JUPYTER_FORWARD_SSH_TEST_USER']}@{os.environ['JUPYTER_FORWARD_SSH_TEST_HOSTNAME']}",
         shell=request.param,
-        auth_handler=lambda t, i, p: ['Loremipsumdolorsitamet'] * len(p),
-        fallback_auth_handler=lambda: 'Loremipsumdolorsitamet',
+        auth_handler=dummy_auth_handler,
+        fallback_auth_handler=dummy_fallback_auth_handler,
     )
     try:
         yield remote
@@ -59,8 +67,8 @@ def test_runner_init(port, conda_env, notebook, notebook_dir, port_forwarding, i
         identity=identity,
         port_forwarding=port_forwarding,
         shell=shell,
-        auth_handler=lambda t, i, p: ['Loremipsumdolorsitamet'] * len(p),
-        fallback_auth_handler=lambda: 'Loremipsumdolorsitamet',
+        auth_handler=dummy_auth_handler,
+        fallback_auth_handler=dummy_fallback_auth_handler,
     )
 
     assert remote_runner.port == port
@@ -91,8 +99,8 @@ def test_runner_authentication_error():
     with pytest.raises(SystemExit):
         jupyter_forward.RemoteRunner(
             f"foobar@{os.environ['JUPYTER_FORWARD_SSH_TEST_HOSTNAME']}",
-            auth_handler=lambda t, i, p: ['Loremipsumdolorsitamet'] * len(p),
-            fallback_auth_handler=lambda: 'Loremipsumdolorsitamet',
+            auth_handler=dummy_auth_handler,
+            fallback_auth_handler=dummy_fallback_auth_handler,
         )
 
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -113,6 +113,7 @@ def test_run_command_failure(runner, command):
     with pytest.raises(SystemExit):
         runner.run_command(command)
 
+
 @requires_ssh
 @pytest.mark.parametrize('content', ['echo $HOME', 'echo $(hostname -f)'])
 @pytest.mark.parametrize('runner', SHELLS, indirect=True)
@@ -122,7 +123,6 @@ def test_put_file(runner, content):
 
     out = runner.run_command(f'cat {path}')
     assert content == out
-
 
 
 @requires_ssh

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -140,7 +140,7 @@ def test_put_file(runner, content):
     with tempfile(runner.session) as path:
         runner.put_file(path, content)
 
-        out = runner.run_command(f'cat {path}')
+        out = runner.session.run(f'cat {path}')
         assert content == out.stdout
 
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -74,8 +74,6 @@ def test_runner_init_notebook_dir_error():
             f"{os.environ['JUPYTER_FORWARD_SSH_TEST_USER']}@{os.environ['JUPYTER_FORWARD_SSH_TEST_HOSTNAME']}",
             notebook_dir='~/notebooks/',
             notebook='~/my_notebook.ipynb',
-            auth_handler=lambda t, i, p: ['Loremipsumdolorsitamet'] * len(p),
-            fallback_auth_handler=lambda: 'Loremipsumdolorsitamet',
         )
 
 
@@ -85,8 +83,6 @@ def test_runner_init_port_unavailable():
         jupyter_forward.RemoteRunner(
             f"{os.environ['JUPYTER_FORWARD_SSH_TEST_USER']}@{os.environ['JUPYTER_FORWARD_SSH_TEST_HOSTNAME']}",
             port=22,
-            auth_handler=lambda t, i, p: ['Loremipsumdolorsitamet'] * len(p),
-            fallback_auth_handler=lambda: 'Loremipsumdolorsitamet',
         )
 
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -18,7 +18,7 @@ ON_GITHUB_ACTIONS = os.environ.get('GITHUB_ACTIONS') is not None
 @contextmanager
 def tempfile(session):
     out = session.run('mktemp')
-    path = out.stdout
+    path = out.stdout.strip()
     try:
         yield path
     finally:
@@ -141,8 +141,6 @@ def test_run_command_failure(runner, command):
 @pytest.mark.parametrize('content', ['echo $HOME', 'echo $(hostname -f)'])
 @pytest.mark.parametrize('runner', SHELLS, indirect=True)
 def test_put_file(runner, content):
-    runner._set_log_directory()
-    path = f'{runner.log_dir}/test_file'
     with tempfile(runner.session) as path:
         runner.put_file(path, content)
 


### PR DESCRIPTION
- [x] closes #168

The lower-level `paramiko` library allows using a separate channel to execute something similar to:

``` bash
python -c 'script = "..."; print(script)' | ssh user@host 'cat - >remote_file'
```
where `script` is never evaluated by the shell.

I'm not sure if there's something like this in `fabric`; I couldn't find anything that would avoid using SFTP (which the admins on my HPC disabled). There were references to SCP in the documentation of `fabric`, but I don't think we should depend on that: as far as I remember, that protocol is deprecated.

I tried to include a test, but I can't seem to understand the test setup so I can't verify if it passes (I guess I will need to wait on CI for that).