### PR TITLE
capture test output

### DIFF
--- a/jupyter_forward/core.py
+++ b/jupyter_forward/core.py
@@ -10,7 +10,7 @@ import time
 
 import invoke
 import paramiko
-from fabric import Connection
+from fabric import Config, Connection
 from rich.console import Console
 
 from .helpers import _authentication_handler, is_port_available, open_browser, parse_stdout
@@ -70,7 +70,10 @@ class RemoteRunner:
         if self.identity:
             connect_kwargs['key_filename'] = [str(self.identity)]
 
-        self.session = Connection(self.host, connect_kwargs=connect_kwargs, forward_agent=True)
+        config = Config(overrides={'run': {'in_stream': False}})
+        self.session = Connection(
+            self.host, connect_kwargs=connect_kwargs, forward_agent=True, config=config
+        )
         self.console.print(
             f'[bold cyan]Authenticating user ({self.session.user}) from client ({socket.gethostname()}) to remote host ({self.session.host})'
         )

--- a/jupyter_forward/core.py
+++ b/jupyter_forward/core.py
@@ -12,8 +12,8 @@ from typing import Callable
 import invoke
 import paramiko
 from fabric import Config, Connection
-from rich.console import Console
 
+from .console import console
 from .helpers import _authentication_handler, is_port_available, open_browser, parse_stdout
 
 timestamp = datetime.datetime.now().strftime('%Y-%m-%dT%H-%M-%S')
@@ -44,7 +44,6 @@ class RemoteRunner:
     launch_command: str = None
     identity: str = None
     shell: str = None
-    console: Console = None
     auth_handler: Callable = _authentication_handler
     fallback_auth_handler: Callable = getpass.getpass
 
@@ -55,11 +54,9 @@ class RemoteRunner:
             self.notebook = pathlib.Path(self.notebook)
             self.notebook_dir = str(self.notebook.parent)
             self.notebook = self.notebook.name
-        if self.console is None:
-            self.console = Console()
 
         if self.port_forwarding and not is_port_available(self.port):
-            self.console.print(
+            console.print(
                 f'''[bold red]:x: Specified port={self.port} is already in use on your local machine. Try a different port'''
             )
             sys.exit(1)
@@ -67,7 +64,7 @@ class RemoteRunner:
         self._check_shell()
 
     def _authenticate(self):
-        self.console.rule('[bold green]Authenticating', characters='*')
+        console.rule('[bold green]Authenticating', characters='*')
 
         connect_kwargs = {}
         if self.identity:
@@ -77,7 +74,7 @@ class RemoteRunner:
         self.session = Connection(
             self.host, connect_kwargs=connect_kwargs, forward_agent=True, config=config
         )
-        self.console.print(
+        console.print(
             f'[bold cyan]Authenticating user ({self.session.user}) from client ({socket.gethostname()}) to remote host ({self.session.host})'
         )
         # Try passwordless authentication
@@ -104,13 +101,13 @@ class RemoteRunner:
                     self.session.transport = loc_transport
                     break
                 except Exception:
-                    self.console.log('[bold red]:x: Failed to Authenticate your connection')
+                    console.log('[bold red]:x: Failed to Authenticate your connection')
         if not self.session.is_connected:
             sys.exit(1)
-        self.console.print('[bold cyan]:white_check_mark: The client is authenticated successfully')
+        console.print('[bold cyan]:white_check_mark: The client is authenticated successfully')
 
     def _check_shell(self):
-        self.console.rule('[bold green]Verifying shell location', characters='*')
+        console.rule('[bold green]Verifying shell location', characters='*')
         if self.shell is None:
             shell = self.session.run('echo $SHELL || echo $0', hide='out').stdout.strip()
             if not shell:
@@ -119,7 +116,7 @@ class RemoteRunner:
         else:
             # Get the full path to the shell in case the user specified a shell name
             self.shell = self.run_command(f'which {self.shell}').stdout.strip()
-        self.console.print(f'[bold cyan]:white_check_mark: Using shell: {self.shell}')
+        console.print(f'[bold cyan]:white_check_mark: Using shell: {self.shell}')
 
     def run_command(
         self,
@@ -144,11 +141,11 @@ class RemoteRunner:
 
     def setup_port_forwarding(self):
         """Sets up SSH port forwarding"""
-        self.console.rule('[bold green]Setting up port forwarding', characters='*')
+        console.rule('[bold green]Setting up port forwarding', characters='*')
         local_port = int(self.port)
         remote_port = int(self.parsed_result['port'])
         remote_host = self.parsed_result['hostname']
-        self.console.print(
+        console.print(
             f'remote_host: {remote_host}, remote_port: {remote_port}, local_port: {local_port}'
         )
         with self.session.forward_local(
@@ -175,10 +172,10 @@ class RemoteRunner:
         try:
             self._launch_jupyter()
         except Exception as exc:
-            self.console.print(f'[bold red]:x: {exc}')
+            console.print(f'[bold red]:x: {exc}')
             self.close()
         finally:
-            self.console.rule(
+            console.rule(
                 f'[bold red]:x: Terminated the network 📡 connection to {self.session.host}',
                 characters='*',
             )
@@ -203,7 +200,7 @@ class RemoteRunner:
         if self.launch_command:
             command = f'{self.launch_command} {self._prepare_batch_job_script(command)}'
 
-        self.console.rule('[bold green]Launching Jupyter Lab', characters='*')
+        console.rule('[bold green]Launching Jupyter Lab', characters='*')
         self.run_command(command, asynchronous=True)
         self.parsed_result = self._parse_log_file()
 
@@ -220,7 +217,7 @@ class RemoteRunner:
             return f'{command} > {log_file} 2>&1'
 
     def _conda_activate_cmd(self):
-        self.console.rule(
+        console.rule(
             '[bold green]Running jupyter sanity checks',
             characters='*',
         )
@@ -230,7 +227,7 @@ class RemoteRunner:
             try:
                 self.run_command(f'{conda_activate_cmd} {self.conda_env} && {check_jupyter_status}')
             except SystemExit:
-                self.console.print(
+                console.print(
                     f'[bold red]:x: `{conda_activate_cmd}` failed. Trying `conda activate`...'
                 )
                 self.run_command(f'conda activate {self.conda_env} && {check_jupyter_status}')
@@ -243,7 +240,7 @@ class RemoteRunner:
         # wait for logfile to contain access info, then write it to screen
         condition = True
         stdout = None
-        with self.console.status(
+        with console.status(
             f'[bold cyan]Parsing {self.log_file} log file on {self.session.host} for jupyter information',
             spinner='weather',
         ):
@@ -259,7 +256,7 @@ class RemoteRunner:
         return parse_stdout(stdout)
 
     def _prepare_batch_job_script(self, command):
-        self.console.rule('[bold green]Preparing Batch Job script', characters='*')
+        console.rule('[bold green]Preparing Batch Job script', characters='*')
         script_file = f'{self.log_dir}/batch_job_script_{timestamp}'
         shell = self.shell
         if 'csh' not in shell:
@@ -271,16 +268,14 @@ class RemoteRunner:
             f'chmod +x {script_file}',
         ]:
             self.run_command(command=command, exit=True)
-        self.console.print(
-            f'[bold cyan]:white_check_mark: Batch Job script resides in {script_file}'
-        )
+        console.print(f'[bold cyan]:white_check_mark: Batch Job script resides in {script_file}')
         return script_file
 
     def _set_log_file(self):
         log_file = f'{self.log_dir}/log_{timestamp}.txt'
         self.run_command(command=f'touch {log_file}')
         self.log_file = log_file
-        self.console.print(f'[bold cyan]:white_check_mark: Log file is set to {log_file}')
+        console.print(f'[bold cyan]:white_check_mark: Log file is set to {log_file}')
         return self
 
     def _set_log_directory(self):
@@ -289,7 +284,7 @@ class RemoteRunner:
             _tmp_dir_status = self.run_command(command=check_dir_command, exit=False)
             return directory if 'is WRITABLE' in _tmp_dir_status.stdout.strip() else None
 
-        self.console.rule(f'[bold green] Creating log file on {self.session.host}', characters='*')
+        console.rule(f'[bold green] Creating log file on {self.session.host}', characters='*')
         # TODO: Allow users to override this via a `--log-dir`
         log_dir = None
         # Try TMPDIR first if defined
@@ -305,12 +300,12 @@ class RemoteRunner:
                 # Raise an error if neither TMPDIR or HOME are defined
                 tmp_dir_error_message = '$TMPDIR is not defined'
                 home_dir_error_message = '$HOME is not defined'
-                self.console.print(
+                console.print(
                     f'[bold red]:x: Can not determine directory for log file:\n{home_dir_error_message}\n{tmp_dir_error_message}'
                 )
                 sys.exit(1)
         log_dir = f'{log_dir}/.jupyter_forward'
         self.run_command(command=f'mkdir -p {log_dir}')
-        self.console.print(f'[bold cyan]:white_check_mark: Log directory is set to {log_dir}')
+        console.print(f'[bold cyan]:white_check_mark: Log directory is set to {log_dir}')
         self.log_dir = log_dir
         return self

--- a/jupyter_forward/core.py
+++ b/jupyter_forward/core.py
@@ -11,8 +11,8 @@ import time
 import invoke
 import paramiko
 from fabric import Connection
+from rich.console import Console
 
-from .console import console
 from .helpers import _authentication_handler, is_port_available, open_browser, parse_stdout
 
 timestamp = datetime.datetime.now().strftime('%Y-%m-%dT%H-%M-%S')
@@ -43,6 +43,7 @@ class RemoteRunner:
     launch_command: str = None
     identity: str = None
     shell: str = None
+    console: Console = None
 
     def __post_init__(self):
         if self.notebook_dir is not None and self.notebook is not None:
@@ -51,9 +52,11 @@ class RemoteRunner:
             self.notebook = pathlib.Path(self.notebook)
             self.notebook_dir = str(self.notebook.parent)
             self.notebook = self.notebook.name
+        if self.console is None:
+            self.console = Console()
 
         if self.port_forwarding and not is_port_available(self.port):
-            console.print(
+            self.console.print(
                 f'''[bold red]:x: Specified port={self.port} is already in use on your local machine. Try a different port'''
             )
             sys.exit(1)
@@ -61,14 +64,14 @@ class RemoteRunner:
         self._check_shell()
 
     def _authenticate(self):
-        console.rule('[bold green]Authenticating', characters='*')
+        self.console.rule('[bold green]Authenticating', characters='*')
 
         connect_kwargs = {}
         if self.identity:
             connect_kwargs['key_filename'] = [str(self.identity)]
 
         self.session = Connection(self.host, connect_kwargs=connect_kwargs, forward_agent=True)
-        console.print(
+        self.console.print(
             f'[bold cyan]Authenticating user ({self.session.user}) from client ({socket.gethostname()}) to remote host ({self.session.host})'
         )
         # Try passwordless authentication
@@ -97,13 +100,13 @@ class RemoteRunner:
                     self.session.transport = loc_transport
                     break
                 except Exception:
-                    console.log('[bold red]:x: Failed to Authenticate your connection')
+                    self.console.log('[bold red]:x: Failed to Authenticate your connection')
         if not self.session.is_connected:
             sys.exit(1)
-        console.print('[bold cyan]:white_check_mark: The client is authenticated successfully')
+        self.console.print('[bold cyan]:white_check_mark: The client is authenticated successfully')
 
     def _check_shell(self):
-        console.rule('[bold green]Verifying shell location', characters='*')
+        self.console.rule('[bold green]Verifying shell location', characters='*')
         if self.shell is None:
             shell = self.session.run('echo $SHELL || echo $0', hide='out').stdout.strip()
             if not shell:
@@ -112,7 +115,7 @@ class RemoteRunner:
         else:
             # Get the full path to the shell in case the user specified a shell name
             self.shell = self.run_command(f'which {self.shell}').stdout.strip()
-        console.print(f'[bold cyan]:white_check_mark: Using shell: {self.shell}')
+        self.console.print(f'[bold cyan]:white_check_mark: Using shell: {self.shell}')
 
     def run_command(
         self,
@@ -137,11 +140,11 @@ class RemoteRunner:
 
     def setup_port_forwarding(self):
         """Sets up SSH port forwarding"""
-        console.rule('[bold green]Setting up port forwarding', characters='*')
+        self.console.rule('[bold green]Setting up port forwarding', characters='*')
         local_port = int(self.port)
         remote_port = int(self.parsed_result['port'])
         remote_host = self.parsed_result['hostname']
-        console.print(
+        self.console.print(
             f'remote_host: {remote_host}, remote_port: {remote_port}, local_port: {local_port}'
         )
         with self.session.forward_local(
@@ -168,10 +171,10 @@ class RemoteRunner:
         try:
             self._launch_jupyter()
         except Exception as exc:
-            console.print(f'[bold red]:x: {exc}')
+            self.console.print(f'[bold red]:x: {exc}')
             self.close()
         finally:
-            console.rule(
+            self.console.rule(
                 f'[bold red]:x: Terminated the network 📡 connection to {self.session.host}',
                 characters='*',
             )
@@ -196,7 +199,7 @@ class RemoteRunner:
         if self.launch_command:
             command = f'{self.launch_command} {self._prepare_batch_job_script(command)}'
 
-        console.rule('[bold green]Launching Jupyter Lab', characters='*')
+        self.console.rule('[bold green]Launching Jupyter Lab', characters='*')
         self.run_command(command, asynchronous=True)
         self.parsed_result = self._parse_log_file()
 
@@ -213,7 +216,7 @@ class RemoteRunner:
             return f'{command} > {log_file} 2>&1'
 
     def _conda_activate_cmd(self):
-        console.rule(
+        self.console.rule(
             '[bold green]Running jupyter sanity checks',
             characters='*',
         )
@@ -223,7 +226,7 @@ class RemoteRunner:
             try:
                 self.run_command(f'{conda_activate_cmd} {self.conda_env} && {check_jupyter_status}')
             except SystemExit:
-                console.print(
+                self.console.print(
                     f'[bold red]:x: `{conda_activate_cmd}` failed. Trying `conda activate`...'
                 )
                 self.run_command(f'conda activate {self.conda_env} && {check_jupyter_status}')
@@ -236,7 +239,7 @@ class RemoteRunner:
         # wait for logfile to contain access info, then write it to screen
         condition = True
         stdout = None
-        with console.status(
+        with self.console.status(
             f'[bold cyan]Parsing {self.log_file} log file on {self.session.host} for jupyter information',
             spinner='weather',
         ):
@@ -252,7 +255,7 @@ class RemoteRunner:
         return parse_stdout(stdout)
 
     def _prepare_batch_job_script(self, command):
-        console.rule('[bold green]Preparing Batch Job script', characters='*')
+        self.console.rule('[bold green]Preparing Batch Job script', characters='*')
         script_file = f'{self.log_dir}/batch_job_script_{timestamp}'
         shell = self.shell
         if 'csh' not in shell:
@@ -264,14 +267,16 @@ class RemoteRunner:
             f'chmod +x {script_file}',
         ]:
             self.run_command(command=command, exit=True)
-        console.print(f'[bold cyan]:white_check_mark: Batch Job script resides in {script_file}')
+        self.console.print(
+            f'[bold cyan]:white_check_mark: Batch Job script resides in {script_file}'
+        )
         return script_file
 
     def _set_log_file(self):
         log_file = f'{self.log_dir}/log_{timestamp}.txt'
         self.run_command(command=f'touch {log_file}')
         self.log_file = log_file
-        console.print(f'[bold cyan]:white_check_mark: Log file is set to {log_file}')
+        self.console.print(f'[bold cyan]:white_check_mark: Log file is set to {log_file}')
         return self
 
     def _set_log_directory(self):
@@ -280,7 +285,7 @@ class RemoteRunner:
             _tmp_dir_status = self.run_command(command=check_dir_command, exit=False)
             return directory if 'is WRITABLE' in _tmp_dir_status.stdout.strip() else None
 
-        console.rule(f'[bold green] Creating log file on {self.session.host}', characters='*')
+        self.console.rule(f'[bold green] Creating log file on {self.session.host}', characters='*')
         # TODO: Allow users to override this via a `--log-dir`
         log_dir = None
         # Try TMPDIR first if defined
@@ -296,12 +301,12 @@ class RemoteRunner:
                 # Raise an error if neither TMPDIR or HOME are defined
                 tmp_dir_error_message = '$TMPDIR is not defined'
                 home_dir_error_message = '$HOME is not defined'
-                console.print(
+                self.console.print(
                     f'[bold red]:x: Can not determine directory for log file:\n{home_dir_error_message}\n{tmp_dir_error_message}'
                 )
                 sys.exit(1)
         log_dir = f'{log_dir}/.jupyter_forward'
         self.run_command(command=f'mkdir -p {log_dir}')
-        console.print(f'[bold cyan]:white_check_mark: Log directory is set to {log_dir}')
+        self.console.print(f'[bold cyan]:white_check_mark: Log directory is set to {log_dir}')
         self.log_dir = log_dir
         return self

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,4 +20,4 @@ skip=
 
 [tool:pytest]
 console_output_style = count
-addopts = --cov=./ --cov-report=xml --verbose -s -rx
+addopts = --cov=./ --cov-report=xml --verbose -rx

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -20,8 +20,10 @@ def runner(request):
         f"{os.environ['JUPYTER_FORWARD_SSH_TEST_USER']}@{os.environ['JUPYTER_FORWARD_SSH_TEST_HOSTNAME']}",
         shell=request.param,
     )
-    yield remote
-    remote.close()
+    try:
+        yield remote
+    finally:
+        remote.close()
 
 
 @requires_ssh

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -19,6 +19,8 @@ def runner(request):
     remote = jupyter_forward.RemoteRunner(
         f"{os.environ['JUPYTER_FORWARD_SSH_TEST_USER']}@{os.environ['JUPYTER_FORWARD_SSH_TEST_HOSTNAME']}",
         shell=request.param,
+        auth_handler=lambda t, i, p: ['Loremipsumdolorsitamet'] * len(p),
+        fallback_auth_handler=lambda: 'Loremipsumdolorsitamet',
     )
     try:
         yield remote
@@ -46,6 +48,8 @@ def test_runner_init(port, conda_env, notebook, notebook_dir, port_forwarding, i
         identity=identity,
         port_forwarding=port_forwarding,
         shell=shell,
+        auth_handler=lambda t, i, p: ['Loremipsumdolorsitamet'] * len(p),
+        fallback_auth_handler=lambda: 'Loremipsumdolorsitamet',
     )
 
     assert remote_runner.port == port


### PR DESCRIPTION
As detailed in https://github.com/ncar-xdev/jupyter-forward/pull/171#issuecomment-1220483893, this changes the module to avoid reading from stdin, making the test output *much* easier to read.

In particular:
- don't use `getpass.getpass` in the tests (by allowing to pass custom handlers)
- set `invoke`'s `run.in_stream` parameter to `False`
- don't use the `-s` option to `pytest`

While the former is good practice in general, the latter means that the remote process can't read from `stdin`. I don't think that's an issue, but if I'm mistaken we can just allow passing a `fabric.Config` object to `RemoteRunner.__init__` and use that in the tests.