### PR TITLE
improve the stdout parsing

### DIFF
--- a/jupyter_forward/helpers.py
+++ b/jupyter_forward/helpers.py
@@ -7,6 +7,10 @@ import urllib.parse
 
 from .console import console
 
+info_re = r'\[[CWI] (?:\d{4}-\d{2}-\d{2} )?\d{2}:\d{2}:\d{2}.\d{3} (?:Server|Lab)App\]'
+url_re = r'http[s]?://(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*\(\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+'
+full_re = re.compile(rf'{info_re}.+(?P<url>{url_re})')
+
 
 def open_browser(port: int = None, token: str = None, url: str = None, path=None) -> None:
     """Opens notebook interface in a new browser window.
@@ -65,12 +69,7 @@ def parse_stdout(stdout: str) -> dict[str, str]:
     """
 
     hostname, port, token, url = None, None, None, None
-    urls = set(
-        re.findall(
-            r'http[s]?://(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*\(\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+',
-            stdout,
-        )
-    )
+    urls = set(full_re.findall(stdout))
     for url in urls:
         url = url.strip()
         result = urllib.parse.urlparse(url)

--- a/jupyter_forward/helpers.py
+++ b/jupyter_forward/helpers.py
@@ -7,10 +7,6 @@ import urllib.parse
 
 from .console import console
 
-info_re = r'\[[CWI] (?:\d{4}-\d{2}-\d{2} )?\d{2}:\d{2}:\d{2}.\d{3} (?:Server|Lab)App\]'
-url_re = r'http[s]?://(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*\(\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+'
-full_re = re.compile(rf'{info_re}\s+(?:or\s)?(?P<url>{url_re})')
-
 
 def open_browser(port: int = None, token: str = None, url: str = None, path=None) -> None:
     """Opens notebook interface in a new browser window.
@@ -69,7 +65,12 @@ def parse_stdout(stdout: str) -> dict[str, str]:
     """
 
     hostname, port, token, url = None, None, None, None
-    urls = set(full_re.findall(stdout))
+    urls = set(
+        re.findall(
+            r'http[s]?://(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*\(\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+',
+            stdout,
+        )
+    )
     for url in urls:
         url = url.strip()
         result = urllib.parse.urlparse(url)

--- a/jupyter_forward/helpers.py
+++ b/jupyter_forward/helpers.py
@@ -9,7 +9,7 @@ from .console import console
 
 info_re = r'\[[CWI] (?:\d{4}-\d{2}-\d{2} )?\d{2}:\d{2}:\d{2}.\d{3} (?:Server|Lab)App\]'
 url_re = r'http[s]?://(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*\(\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+'
-full_re = re.compile(rf'{info_re}.+(?P<url>{url_re})')
+full_re = re.compile(rf'{info_re}\s+(?:or\s)?(?P<url>{url_re})')
 
 
 def open_browser(port: int = None, token: str = None, url: str = None, path=None) -> None:

--- a/jupyter_forward/helpers.py
+++ b/jupyter_forward/helpers.py
@@ -76,8 +76,9 @@ def parse_stdout(stdout: str) -> dict[str, str]:
         if result.hostname != '127.0.0.1' and result.port:
             hostname = result.hostname
             port = result.port
-            if 'token' in result.query:
-                token = result.query.split('token=')[-1].strip()
+
+            params = urllib.parse.parse_qs(result.query)
+            token = params.get('token', [None])[0]
             break
     return {'hostname': hostname, 'port': port, 'token': token, 'url': url}
 

--- a/jupyter_forward/helpers.py
+++ b/jupyter_forward/helpers.py
@@ -73,9 +73,10 @@ def parse_stdout(stdout: str) -> dict[str, str]:
     )
     for url in urls:
         url = url.strip()
-        if '127.0.0.1' not in url:
-            result = urllib.parse.urlparse(url)
-            hostname, port = result.netloc.split(':')
+        result = urllib.parse.urlparse(url)
+        if result.hostname != '127.0.0.1' and result.port:
+            hostname = result.hostname
+            port = result.port
             if 'token' in result.query:
                 token = result.query.split('token=')[-1].strip()
             break

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,7 +4,7 @@ ignore =
 max-line-length = 100
 max-complexity = 18
 select = B,C,E,F,W,T4,B9
-extend-ignore = E203,E501,E402,W605
+extend-ignore = E203,E501,E402,W605,W503
 
 [isort]
 known_first_party=jupyter_forward

--- a/tests/misc.py
+++ b/tests/misc.py
@@ -12,3 +12,6 @@ sample_log_file_contents = [
     'http://eniac01:59628/?token=Loremipsumdolorsitamet',
     'or http://127.0.0.1:59628/?token=Loremipsumdolorsitamet',
 ]
+sample_log_file_contents_with_contamination = [
+    '{"type":"info","data":"Visit https://yarnpkg.com/en/docs/cli/config for documentation about this command."}'
+] + sample_log_file_contents

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -184,7 +184,7 @@ def test_parse_log_file(runner):
     out = runner._parse_log_file()
     assert out == {
         'hostname': 'eniac01',
-        'port': '59628',
+        'port': 59628,
         'token': 'Loremipsumdolorsitamet',
         'url': 'http://eniac01:59628/?token=Loremipsumdolorsitamet',
     }

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -178,9 +178,8 @@ def test_prepare_batch_job_script(runner):
 def test_parse_log_file(runner):
     runner._set_log_directory()
     runner._set_log_file()
-    runner.run_command(f"echo '{sample_log_file_contents[0]}' > {runner.log_file}")
-    for line in sample_log_file_contents[1:]:
-        runner.run_command(f"echo '{line}' >> {runner.log_file}")
+    content = ''.join(f'{line}\n' for line in sample_log_file_contents)
+    runner.put_file(runner.log_file, content)
     out = runner._parse_log_file()
     assert out == {
         'hostname': 'eniac01',

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -15,7 +15,19 @@ from .misc import sample_log_file_contents
             sample_log_file_contents,
             {
                 'hostname': 'eniac01',
-                'port': '59628',
+                'port': 59628,
+                'token': 'Loremipsumdolorsitamet',
+                'url': 'http://eniac01:59628/?token=Loremipsumdolorsitamet',
+            },
+        ),
+        (
+            [
+                '{"type":"info","data":"Visit https://yarnpkg.com/en/docs/cli/config for documentation about this command."}'
+            ]
+            + sample_log_file_contents,
+            {
+                'hostname': 'eniac01',
+                'port': 59628,
                 'token': 'Loremipsumdolorsitamet',
                 'url': 'http://eniac01:59628/?token=Loremipsumdolorsitamet',
             },

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -5,7 +5,7 @@ import pytest
 
 import jupyter_forward.helpers
 
-from .misc import sample_log_file_contents
+from .misc import sample_log_file_contents, sample_log_file_contents_with_contamination
 
 
 @pytest.mark.parametrize(
@@ -21,10 +21,7 @@ from .misc import sample_log_file_contents
             },
         ),
         (
-            [
-                '{"type":"info","data":"Visit https://yarnpkg.com/en/docs/cli/config for documentation about this command."}'
-            ]
-            + sample_log_file_contents,
+            sample_log_file_contents_with_contamination,
             {
                 'hostname': 'eniac01',
                 'port': 59628,


### PR DESCRIPTION
The last remaining issue I had with `jupyter-forward` is that jupyterlab would sometimes log warnings from `yarn` (something about not being able to open a configuration file), which unfortunately also contains a url. This url is then the first one `parse_stdout` tries to parse and fails, because it doesn't contain a port.

I think there are two options to fix this: improve the regular expression, or filter the set of extracted urls. The latter is probably easier to implement but less general, while the former is more sensitive to changes in the log output (not sure how likely that is to happen, though).

I would be open to implementing both, but I would imagine the filtering to be a bit easier (which is why I chose to implement that in this PR).