### PR TITLE
use the `run` command of `conda` / `mamba` / `micromamba` and support `pixi`

### DIFF
--- a/jupyter_forward/cli.py
+++ b/jupyter_forward/cli.py
@@ -25,6 +25,9 @@ def start(
         ),
         show_default=True,
     ),
+    env_manager: str = typer.Option(
+        None, '--env-manager', show_default=True, help='Name or path of the environment manager.'
+    ),
     conda_env: str = typer.Option(
         None,
         show_default=True,
@@ -86,6 +89,7 @@ def start(
     runner = RemoteRunner(
         host,
         port=port,
+        env_manager=env_manager,
         conda_env=conda_env,
         notebook_dir=notebook_dir,
         notebook=notebook,

--- a/jupyter_forward/cli.py
+++ b/jupyter_forward/cli.py
@@ -26,7 +26,13 @@ def start(
         show_default=True,
     ),
     env_manager: str = typer.Option(
-        None, '--env-manager', show_default=True, help='Name or path of the environment manager.'
+        None, '--environment-manager', show_default=True, help='Name of the environment manager.'
+    ),
+    env_manager_path: str = typer.Option(
+        None,
+        '--environment-manager-path',
+        show_default=True,
+        help='Path of the environment manager.',
     ),
     conda_env: str = typer.Option(
         None,
@@ -90,6 +96,7 @@ def start(
         host,
         port=port,
         env_manager=env_manager,
+        env_manager_path=env_manager_path,
         conda_env=conda_env,
         notebook_dir=notebook_dir,
         notebook=notebook,

--- a/jupyter_forward/cli.py
+++ b/jupyter_forward/cli.py
@@ -1,3 +1,4 @@
+from enum import Enum
 from pathlib import Path
 
 import typer
@@ -5,6 +6,13 @@ import typer
 from .core import RemoteRunner
 
 app = typer.Typer(help='Jupyter Lab Port Forwarding Utility')
+
+
+class EnvironmentManager(str, Enum):
+    micromamba = 'micromamba'
+    mamba = 'mamba'
+    conda = 'conda'
+    pixi = 'pixi'
 
 
 def version_callback(value: bool):
@@ -23,16 +31,16 @@ def start(
         help=(
             """The local port the remote notebook server will be forwarded to. If not specified, defaults to 8888."""
         ),
-        show_default=True,
     ),
-    env_manager: str = typer.Option(
-        None, '--environment-manager', show_default=True, help='Name of the environment manager.'
+    env_manager: EnvironmentManager | None = typer.Option(
+        None,
+        '--environment-manager',
+        help='Name of the environment manager. If not specified will check the conda-like managers in sequence.',
     ),
     env_manager_path: str = typer.Option(
         None,
         '--environment-manager-path',
-        show_default=True,
-        help='Path of the environment manager.',
+        help="Path of the environment manager. If not specified, it will be inferred from the environment manager's name.",
     ),
     conda_env: str = typer.Option(
         None,

--- a/jupyter_forward/core.py
+++ b/jupyter_forward/core.py
@@ -40,6 +40,7 @@ class RemoteRunner:
     host: str
     port: int = 8888
     env_manager: str | None = None
+    env_manager_path: str | None = None
     conda_env: str | None = None
     notebook_dir: str | None = None
     notebook: str | None = None

--- a/jupyter_forward/core.py
+++ b/jupyter_forward/core.py
@@ -39,6 +39,7 @@ class RemoteRunner:
 
     host: str
     port: int = 8888
+    env_manager: str | None = None
     conda_env: str | None = None
     notebook_dir: str | None = None
     notebook: str | None = None

--- a/jupyter_forward/core.py
+++ b/jupyter_forward/core.py
@@ -365,40 +365,6 @@ class RemoteRunner:
             console.print(f'[bold yellow]:warning: `{command.lower()}` check failed: {e}')
             return False
 
-    def _conda_activate_cmd(self):
-        console.rule(
-            '[bold green]Running Jupyter sanity checks',
-            characters='*',
-        )
-        check_jupyter_status = 'which jupyter'
-        activate_cmds = ['source activate', 'conda activate']
-
-        # Check for micrmamba, then mamba availability and prioritize
-        # which ever is found first
-        if self._command_exists('micromamba'):
-            activate_cmds = ['micromamba activate']
-        elif self._command_exists('mamba'):
-            activate_cmds = ['mamba activate']
-        else:
-            console.print('[bold yellow]:warning: (micro)mamba not found. Using conda instead.')
-
-        # Attempt activation
-        if self.conda_env:
-            for cmd in activate_cmds:
-                try:
-                    self.run_command(f'{cmd} {self.conda_env} && {check_jupyter_status}')
-                    return cmd  # Return the successfully executed command
-                except SystemExit:
-                    console.print(f'[bold red]:x: `{cmd}` failed. Trying next...')
-        else:
-            self.run_command(check_jupyter_status)
-
-        # Final fallback if all commands fail
-        console.print(
-            '[bold red]:x: Could not activate environment. Ensure Conda or Mamba is installed.'
-        )
-        sys.exit(1)
-
     def _parse_log_file(self):
         # wait for logfile to contain access info, then write it to screen
         condition = True

--- a/jupyter_forward/core.py
+++ b/jupyter_forward/core.py
@@ -338,12 +338,6 @@ class RemoteRunner:
         else:
             command = self._create_template(script=False).format(command=command)
 
-        from rich.syntax import Syntax
-
-        console.rule('[bold green]Launching Jupyter Lab', characters='*')
-        console.print(Syntax(command, 'bash'))
-        console.print('[bold yellow]:warning: exiting before executing')
-        sys.exit(1)
         self.run_command(command, asynchronous=True)
         self.parsed_result = self._parse_log_file()
 

--- a/jupyter_forward/core.py
+++ b/jupyter_forward/core.py
@@ -197,15 +197,15 @@ class RemoteRunner:
             sys.exit(1)
 
         if ':' in self.conda_env:
-            project, env = self.env.rsplit(':', maxsplit=1)
+            project, env = self.conda_env.rsplit(':', maxsplit=1)
             option = f'-e {env}'
         else:
-            project = self.env
+            project = self.conda_env
             option = ''
 
         if self.env_manager_path is None:
             try:
-                self.env_manager_path = self.run_command('which pixi')
+                self.env_manager_path = self.run_command('which pixi').stdout.strip()
             except SystemExit:
                 console.print(
                     '[bold red]:x: Could not find pixi.'
@@ -219,7 +219,9 @@ class RemoteRunner:
         )
 
         try:
-            self.run_command(f'CWD="{project}" pixi run {option} which jupyter')
+            self.run_command(
+                f'cd && cd {project} && {self.env_manager_path} run {option} which jupyter'
+            )
         except SystemExit:
             console.print(
                 '[bold red]:x: Checking for `jupyter` failed.'

--- a/jupyter_forward/core.py
+++ b/jupyter_forward/core.py
@@ -16,7 +16,13 @@ import paramiko
 from fabric import Config, Connection
 
 from .console import console
-from .helpers import _authentication_handler, is_port_available, open_browser, parse_stdout
+from .helpers import (
+    _authentication_handler,
+    is_path,
+    is_port_available,
+    open_browser,
+    parse_stdout,
+)
 
 timestamp = datetime.datetime.now().strftime('%Y-%m-%dT%H-%M-%S')
 
@@ -125,6 +131,130 @@ class RemoteRunner:
             channel.exec_command(f'cat > {remote_path}')
             channel.sendall(content.encode())
 
+    def _create_template_conda_like(self, script):
+        if self.conda_env is not None:
+            if is_path(self.conda_env):
+                option = f'-p {self.conda_env}'
+            else:
+                option = f'-n {self.conda_env}'
+        else:
+            option = ''
+
+        if self.env_manager is None:
+            if self._command_exists('micromamba'):
+                self.env_manager = 'micromamba'
+            elif self._command_exists('mamba'):
+                self.env_manager = 'mamba'
+            elif self._command_exists('conda'):
+                self.env_manager = 'conda'
+            else:
+                console.print(
+                    '[bold red]:x: no conda-like package manager found.'
+                    ' Ensure micromamba, mamba, or conda are installed.'
+                )
+                sys.exit(1)
+
+        if self.env_manager_path is None:
+            try:
+                self.env_manager_path = self.run_command(f'which {self.env_manager}').stdout.strip()
+            except SystemExit:
+                console.print(
+                    f'[bold red]:x: Could not find {self.env_manager}.'
+                    ' Make sure it is in path, or provide an absolute path using `--env-manager-path`.'
+                )
+                raise
+
+        manager = self.env_manager
+        cmd = self.env_manager_path
+
+        console.rule(
+            f'[bold green]Running Jupyter sanity checks ({manager})',
+            characters='*',
+        )
+        try:
+            self.run_command(f'{cmd} run {option} which jupyter')
+        except SystemExit:
+            console.print(
+                '[bold red]:x: Checking for `jupyter` failed.'
+                ' Make sure your environment exists and has `jupyter` installed.'
+            )
+            raise
+
+        if script:
+            return textwrap.dedent(
+                f"""\
+                #!/usr/bin/env {self.shell}
+
+                {cmd} run {option} {{command}}
+                """.rstrip()
+            )
+        else:
+            return f'{cmd} run {option} {{command}}'
+
+    def _create_template_pixi(self, script):
+        if self.conda_env is None:
+            console.print('[bold red]:x: Pixi global installations are not supported for now.')
+            sys.exit(1)
+
+        if ':' in self.conda_env:
+            project, env = self.env.rsplit(':', maxsplit=1)
+            option = f'-e {env}'
+        else:
+            project = self.env
+            option = ''
+
+        if self.env_manager_path is None:
+            try:
+                self.env_manager_path = self.run_command('which pixi')
+            except SystemExit:
+                console.print(
+                    '[bold red]:x: Could not find pixi.'
+                    ' Make sure it is in path, or provide an absolute path using `--env-manager-path`.'
+                )
+                raise
+
+        console.rule(
+            '[bold green]Running Jupyter sanity checks (pixi)',
+            characters='*',
+        )
+
+        try:
+            self.run_command(f'CWD="{project}" pixi run {option} which jupyter')
+        except SystemExit:
+            console.print(
+                '[bold red]:x: Checking for `jupyter` failed.'
+                ' Make sure your environment exists and has `jupyter` installed.'
+            )
+            raise
+
+        if script:
+            return textwrap.dedent(
+                f"""\
+                #!/usr/bin/env {self.shell}
+
+                cd {project}
+                {self.env_manager_path} run {option} {{command}}
+                """.rstrip()
+            )
+        else:
+            return f'cd "{project}" && {self.env_manager_path} run {option} {{command}}'
+
+    def _create_template(self, script):
+        env_managers = {
+            'micromamba': self._create_template_conda_like,
+            'mamba': self._create_template_conda_like,
+            'conda': self._create_template_conda_like,
+            None: self._create_template_conda_like,
+            'pixi': self._create_template_pixi,
+        }
+
+        template_creator = env_managers.get(self.env_manager)
+        if template_creator is None:
+            console.print(f'[bold red]:x: Unknown environment manager ({self.env_manager})')
+            sys.exit(1)
+
+        return template_creator(script)
+
     def run_command(
         self,
         command,
@@ -194,20 +324,24 @@ class RemoteRunner:
             return self.session.run('hostname -f').stdout.strip()
 
     def _launch_jupyter(self):
-        conda_activate_cmd = self._conda_activate_cmd()
         self._set_log_directory()
         self._set_log_file()
         command = rf'jupyter lab --no-browser --ip={self._get_hostname()}'
         if self.notebook_dir:
             command = f'{command} --notebook-dir={self.notebook_dir}'
         command = self._generate_redirect_command(command=command, log_file=self.log_file)
-        if self.conda_env:
-            command = f'{conda_activate_cmd} {self.conda_env} && {command}'
 
         if self.launch_command:
             command = f'{self.launch_command} {self._prepare_batch_job_script(command)}'
+        else:
+            command = self._create_template(script=False).format(command=command)
+
+        from rich.syntax import Syntax
 
         console.rule('[bold green]Launching Jupyter Lab', characters='*')
+        console.print(Syntax(command, 'bash'))
+        console.print('[bold yellow]:warning: exiting before executing')
+        sys.exit(1)
         self.run_command(command, asynchronous=True)
         self.parsed_result = self._parse_log_file()
 
@@ -291,13 +425,10 @@ class RemoteRunner:
         if 'csh' not in shell:
             shell = f'{shell} -l'
 
-        script = textwrap.dedent(
-            f"""\
-            #!{shell}
-            {command}
-            """
-        )
+        template = self._create_template(script=True)
+        script = template.format(command=command)
         console.print(Syntax(script, 'bash', line_numbers=True))
+
         self.put_file(script_file, script)
         self.run_command(f'chmod +x {script_file}', exit=True)
         console.print(f'[bold cyan]:white_check_mark: Batch Job script resides in {script_file}')

--- a/jupyter_forward/core.py
+++ b/jupyter_forward/core.py
@@ -16,6 +16,7 @@ import paramiko
 from fabric import Config, Connection
 
 from .console import console
+from .environments import Bare, CondaLike, environment_managers
 from .helpers import (
     _authentication_handler,
     is_path,
@@ -325,6 +326,85 @@ class RemoteRunner:
         else:
             return self.session.run('hostname -f').stdout.strip()
 
+    def _infer_environment_manager(self):
+        console.rule('[bold green]Selecting a environment manager', characters='*')
+        if self.conda_env is None:
+            console.print('No environment set, no environment manager necessary')
+            return Bare()
+
+        if self.env_manager is not None:
+            console.print(f'[bold green]Environment manager {self.env_manager} requested.')
+            manager_cls = environment_managers.get(self.env_manager)
+            if manager_cls is None:
+                console.print(
+                    f'[bold red]:x: Unknown environment manager: {self.env_manager}. Terminating.'
+                )
+                sys.exit(1)
+
+            if self.env_manager_path is not None:
+                result = self.run_command(f'ls {self.env_manager_path}', exit=False)
+                if result.failed:
+                    console.print(
+                        f'[bold red]:x: Environment manager at {self.env_manager_path}'
+                        ' does not exist. Terminating.'
+                    )
+                    sys.exit(1)
+                else:
+                    console.print(
+                        '[bold green]:white_check_mark: Environment manager'
+                        f' at {self.env_manager_path} found.'
+                    )
+            else:
+                result = self.run_command(f'which {self.env_manager}', exit=False)
+                if result.failed:
+                    console.print(
+                        f'[bold red]:x: Environment manager {self.env_manager}'
+                        ' not in $PATH. Terminating.'
+                    )
+                    sys.exit(1)
+                console.print(
+                    '[bold green]:white_check_mark: Found environment manager'
+                    f' {self.env_manager} in $PATH.'
+                )
+
+                self.env_manager_path = result.stdout.strip()
+
+            return manager_cls(self.env_manager, self.env_manager_path)
+
+        console.rule(
+            '[bold green]No environment manager chosen, falling back to a conda-like environment manager.',
+            characters='*',
+        )
+        for index, name in enumerate(CondaLike.executable_names):
+            console.print(f'Trying {name}...')
+            result = self.run_command(f'which {name}', exit=False)
+            if result.failed:
+                message = '[bold yellow]:warning: {name} not found.'
+                if index < len(CondaLike.executable_names) - 1:
+                    next_ = CondaLike.executable_names[index + 1]
+                    next_action = f'Trying {next_} next.'
+
+                    message += f' {next_action}'
+
+                console.print(message)
+                continue
+
+            self.env_manager_path = result.stdout.strip()
+            self.env_manager = name
+            console.print(f'[bold green]:white_check_mark: Found {name} at {self.env_manager_path}')
+
+            return CondaLike(self.env_manager, self.env_manager_path)
+
+        console.print('[bold red]:x: No more environment managers to try. Terminating.')
+        sys.exit(1)
+
+    @property
+    def execution_shell(self):
+        if 'csh' in self.shell:
+            return f'{self.shell} -c'
+        else:
+            return f'{self.shell} -lc'
+
     def _launch_jupyter(self):
         self._set_log_directory()
         self._set_log_file()
@@ -333,10 +413,25 @@ class RemoteRunner:
             command = f'{command} --notebook-dir={self.notebook_dir}'
         command = self._generate_redirect_command(command=command, log_file=self.log_file)
 
-        if self.launch_command:
-            command = f'{self.launch_command} {self._prepare_batch_job_script(command)}'
+        manager = self._infer_environment_manager()
+
+        console.rule('[bold green]Running Jupyter sanity checks.', characters='*')
+        cmd = manager.execution_template(self.conda_env, script=False).format(
+            shell=self.execution_shell, command='which jupyter'
+        )
+        result = self.run_command(cmd, exit=False)
+        if result.failed:
+            console.print('[bold red]:x: The environment does not contain jupyter. Terminating.')
+            sys.exit(1)
         else:
-            command = self._create_template(script=False).format(command=command)
+            console.print('[bold green]:white_check_mark: Found jupyter in the environment.')
+
+        if self.launch_command:
+            command = f'{self.launch_command} {self._prepare_batch_job_script(manager, command)}'
+        else:
+            command = manager.execution_template(env=self.conda_env, script=False).format(
+                shell=self.execution_shell, command=command
+            )
 
         self.run_command(command, asynchronous=True)
         self.parsed_result = self._parse_log_file()
@@ -378,7 +473,7 @@ class RemoteRunner:
                         stdout = result.stdout
         return parse_stdout(stdout)
 
-    def _prepare_batch_job_script(self, command):
+    def _prepare_batch_job_script(self, manager, command):
         from rich.syntax import Syntax
 
         console.rule('[bold green]Preparing Batch Job script', characters='*')
@@ -387,8 +482,8 @@ class RemoteRunner:
         if 'csh' not in shell:
             shell = f'{shell} -l'
 
-        template = self._create_template(script=True)
-        script = template.format(command=command)
+        template = manager.execution_template(self.conda_env, script=True)
+        script = template.format(shell=self.shell, command=command)
         console.print(Syntax(script, 'bash', line_numbers=True))
 
         self.put_file(script_file, script)

--- a/jupyter_forward/core.py
+++ b/jupyter_forward/core.py
@@ -7,7 +7,6 @@ import getpass
 import pathlib
 import socket
 import sys
-import textwrap
 import time
 from collections.abc import Callable
 
@@ -19,7 +18,6 @@ from .console import console
 from .environments import Bare, CondaLike, environment_managers
 from .helpers import (
     _authentication_handler,
-    is_path,
     is_port_available,
     open_browser,
     parse_stdout,
@@ -131,132 +129,6 @@ class RemoteRunner:
         with client.get_transport().open_channel(kind='session') as channel:
             channel.exec_command(f'cat > {remote_path}')
             channel.sendall(content.encode())
-
-    def _create_template_conda_like(self, script):
-        if self.conda_env is not None:
-            if is_path(self.conda_env):
-                option = f'-p {self.conda_env}'
-            else:
-                option = f'-n {self.conda_env}'
-        else:
-            option = ''
-
-        if self.env_manager is None:
-            if self._command_exists('micromamba'):
-                self.env_manager = 'micromamba'
-            elif self._command_exists('mamba'):
-                self.env_manager = 'mamba'
-            elif self._command_exists('conda'):
-                self.env_manager = 'conda'
-            else:
-                console.print(
-                    '[bold red]:x: no conda-like package manager found.'
-                    ' Ensure micromamba, mamba, or conda are installed.'
-                )
-                sys.exit(1)
-
-        if self.env_manager_path is None:
-            try:
-                self.env_manager_path = self.run_command(f'which {self.env_manager}').stdout.strip()
-            except SystemExit:
-                console.print(
-                    f'[bold red]:x: Could not find {self.env_manager}.'
-                    ' Make sure it is in path, or provide an absolute path using `--environment-manager-path`.'
-                )
-                raise
-
-        manager = self.env_manager
-        cmd = self.env_manager_path
-
-        console.rule(
-            f'[bold green]Running Jupyter sanity checks ({manager})',
-            characters='*',
-        )
-        try:
-            self.run_command(f'{cmd} run {option} which jupyter')
-        except SystemExit:
-            console.print(
-                '[bold red]:x: Checking for `jupyter` failed.'
-                ' Make sure your environment exists and has `jupyter` installed.'
-            )
-            raise
-
-        if script:
-            return textwrap.dedent(
-                f"""\
-                #!/usr/bin/env {self.shell}
-
-                {cmd} run {option} {{command}}
-                """.rstrip()
-            )
-        else:
-            return f'{cmd} run {option} {{command}}'
-
-    def _create_template_pixi(self, script):
-        if self.conda_env is None:
-            console.print('[bold red]:x: Pixi global installations are not supported for now.')
-            sys.exit(1)
-
-        if ':' in self.conda_env:
-            project, env = self.conda_env.rsplit(':', maxsplit=1)
-            option = f'-e {env}'
-        else:
-            project = self.conda_env
-            option = ''
-
-        if self.env_manager_path is None:
-            try:
-                self.env_manager_path = self.run_command('which pixi').stdout.strip()
-            except SystemExit:
-                console.print(
-                    '[bold red]:x: Could not find pixi.'
-                    ' Make sure it is in path, or provide an absolute path using `--env-manager-path`.'
-                )
-                raise
-
-        console.rule(
-            '[bold green]Running Jupyter sanity checks (pixi)',
-            characters='*',
-        )
-
-        try:
-            self.run_command(
-                f'cd && cd {project} && {self.env_manager_path} run {option} which jupyter'
-            )
-        except SystemExit:
-            console.print(
-                '[bold red]:x: Checking for `jupyter` failed.'
-                ' Make sure your environment exists and has `jupyter` installed.'
-            )
-            raise
-
-        if script:
-            return textwrap.dedent(
-                f"""\
-                #!/usr/bin/env {self.shell}
-
-                cd {project}
-                {self.env_manager_path} run {option} {{command}}
-                """.rstrip()
-            )
-        else:
-            return f'cd "{project}" && {self.env_manager_path} run {option} {{command}}'
-
-    def _create_template(self, script):
-        env_managers = {
-            'micromamba': self._create_template_conda_like,
-            'mamba': self._create_template_conda_like,
-            'conda': self._create_template_conda_like,
-            None: self._create_template_conda_like,
-            'pixi': self._create_template_pixi,
-        }
-
-        template_creator = env_managers.get(self.env_manager)
-        if template_creator is None:
-            console.print(f'[bold red]:x: Unknown environment manager ({self.env_manager})')
-            sys.exit(1)
-
-        return template_creator(script)
 
     def run_command(
         self,

--- a/jupyter_forward/core.py
+++ b/jupyter_forward/core.py
@@ -289,7 +289,7 @@ class RemoteRunner:
 
         console.rule('[bold green]Running Jupyter sanity checks.', characters='*')
         cmd = manager.execution_template(self.conda_env, script=False).format(
-            shell=self.execution_shell, command='which jupyter'
+            shell=f'{self.shell} -c', command='which jupyter'
         )
         result = self.run_command(cmd, exit=False)
         if result.failed:

--- a/jupyter_forward/core.py
+++ b/jupyter_forward/core.py
@@ -161,7 +161,7 @@ class RemoteRunner:
             except SystemExit:
                 console.print(
                     f'[bold red]:x: Could not find {self.env_manager}.'
-                    ' Make sure it is in path, or provide an absolute path using `--env-manager-path`.'
+                    ' Make sure it is in path, or provide an absolute path using `--environment-manager-path`.'
                 )
                 raise
 

--- a/jupyter_forward/environments.py
+++ b/jupyter_forward/environments.py
@@ -77,7 +77,7 @@ class Pixi(EnvironmentManager):
                 #!/usr/bin/env {{shell}}
 
                 cd "{project}"
-                {cmd} run {option} {{command}}
+                {cmd} run --frozen {option} {{command}}
                 """.rstrip()
             )
         else:

--- a/jupyter_forward/environments.py
+++ b/jupyter_forward/environments.py
@@ -1,0 +1,92 @@
+import textwrap
+from dataclasses import dataclass
+from typing import ClassVar
+
+from .helpers import is_path
+
+
+@dataclass
+class EnvironmentManager:
+    manager: str
+    path: str | None
+
+    def execution_template(self, script: bool) -> str:
+        pass
+
+
+@dataclass
+class Bare(EnvironmentManager):
+    def execution_template(self, env: str, script: bool) -> str:
+        if script:
+            return textwrap.dedent(
+                """\
+                #!/usr/bin/env {shell}
+
+                {command}
+                """
+            )
+        else:
+            return "{shell} '{command}'"
+
+
+@dataclass
+class CondaLike(EnvironmentManager):
+    manager: str
+    path: str | None = None
+
+    executable_names: ClassVar[list[str]] = ['micromamba', 'mamba', 'conda']
+
+    def execution_template(self, env: str, script: bool) -> str:
+        if is_path(env):
+            option = f'-p {env}'
+        else:
+            option = f'-n {env}'
+
+        cmd = self.path if self.path is not None else self.manager
+
+        if script:
+            return textwrap.dedent(
+                f"""\
+                #!/usr/bin/env {{shell}}
+
+                {cmd} run {option} {{command}}
+                """.rstrip()
+            )
+        else:
+            return f"{cmd} run {option} {{shell}} '{{command}}'"
+
+
+@dataclass
+class Pixi(EnvironmentManager):
+    manager: str = 'pixi'
+    path: str | None = None
+
+    def execution_template(self, env: str, script: bool) -> str:
+        if ':' in env:
+            project, env_name = env.rsplit(':', maxsplit=1)
+            option = f'-e {env_name}'
+        else:
+            project = env
+            option = ''
+
+        cmd = self.path if self.path is not None else self.manager
+
+        if script:
+            return textwrap.dedent(
+                f"""\
+                #!/usr/bin/env {{shell}}
+
+                cd "{project}"
+                {cmd} run {option} {{command}}
+                """.rstrip()
+            )
+        else:
+            return f'cd "{project}" && {cmd} run {option} {{shell}} \'{{command}}\''
+
+
+environment_managers = {
+    'conda': CondaLike,
+    'mamba': CondaLike,
+    'micromamba': CondaLike,
+    'pixi': Pixi,
+}

--- a/jupyter_forward/environments.py
+++ b/jupyter_forward/environments.py
@@ -84,9 +84,32 @@ class Pixi(EnvironmentManager):
             return f'cd "{project}" && {cmd} run {option} {{shell}} \'{{command}}\''
 
 
+@dataclass
+class Uv(EnvironmentManager):
+    manager: str = 'uv'
+    path: str | None = None
+
+    def execution_template(self, env: str, script: bool) -> str:
+        cmd = self.path if self.path is not None else self.manager
+
+        project = env
+        if script:
+            return textwrap.dedent(
+                f"""\
+                #!/usr/bin/env {{shell}}
+
+                cd "{project}"
+                {cmd} run {{command}}
+                """.rstrip()
+            )
+        else:
+            return f'cd "{project}" && {cmd} run {{shell}} \'{{command}}\''
+
+
 environment_managers = {
     'conda': CondaLike,
     'mamba': CondaLike,
     'micromamba': CondaLike,
     'pixi': Pixi,
+    'uv': Uv,
 }

--- a/jupyter_forward/helpers.py
+++ b/jupyter_forward/helpers.py
@@ -95,3 +95,7 @@ def _authentication_handler(title, instructions, prompt_list):
     Handler for paramiko auth_interactive_dumb
     """
     return [getpass.getpass(str(pr[0])) for pr in prompt_list]
+
+
+def is_path(string):
+    return '/' in string or '\\' in string

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -182,6 +182,7 @@ def test_prepare_batch_job_script(runner, environment_manager):
     script = runner.run_command(f'cat {script_file}').stdout.strip()
     assert 'hello world' in script
     assert f'{environment_manager.manager} run' in script
+    assert runner.conda_env in script
 
 
 @requires_ssh

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -51,7 +51,7 @@ def runner(request):
 
 @pytest.fixture(params=MANAGERS)
 def environment_manager(request):
-    return environment_managers[request.param]
+    return environment_managers[request.param]()
 
 
 @requires_ssh

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -6,6 +6,7 @@ from contextlib import contextmanager
 import pytest
 
 import jupyter_forward
+from jupyter_forward.environments import environment_managers
 
 from .misc import sample_log_file_contents
 
@@ -13,7 +14,7 @@ SHELLS = json.loads(os.environ.get('JUPYTER_FORWARD_TEST_SHELLS', '["bash", null
 JUPYTER_FORWARD_ENABLE_SSH_TESTS = os.environ.get('JUPYTER_FORWARD_ENABLE_SSH_TESTS') is None
 requires_ssh = pytest.mark.skipif(JUPYTER_FORWARD_ENABLE_SSH_TESTS, reason='SSH tests disabled')
 ON_GITHUB_ACTIONS = os.environ.get('GITHUB_ACTIONS') is not None
-MANAGERS = ['pixi', 'uv', 'conda', 'mamba', 'micromamba']
+MANAGERS = ['pixi', 'conda', 'mamba', 'micromamba']
 
 
 @contextmanager
@@ -46,6 +47,11 @@ def runner(request):
         yield remote
     finally:
         remote.close()
+
+
+@pytest.fixture(params=MANAGERS)
+def environment_manager(request):
+    return environment_managers[request.param]
 
 
 @requires_ssh
@@ -165,16 +171,15 @@ def test_set_logs(runner):
 
 @requires_ssh
 @pytest.mark.parametrize('runner', SHELLS, indirect=True)
-@pytest.mark.parametrize('manager', MANAGERS)
-def test_prepare_batch_job_script(runner, manager):
+def test_prepare_batch_job_script(runner, environment_manager):
     if ON_GITHUB_ACTIONS and ('csh' in runner.shell):
         pytest.xfail('Fails on GitHub Actions due to inconsistent shell behavior')
     runner._set_log_directory()
-    script_file = runner._prepare_batch_job_script(manager, 'echo hello world')
+    script_file = runner._prepare_batch_job_script(environment_manager, 'echo hello world')
     print('script file:', script_file)
     assert 'batch_job_script' in script_file
     assert 'hello world' in runner.run_command(f'cat {script_file}').stdout.strip()
-    assert f'{manager} run' in script_file
+    assert f'{environment_manager.manager} run' in script_file
 
 
 @requires_ssh

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -175,6 +175,7 @@ def test_prepare_batch_job_script(runner, environment_manager):
     if ON_GITHUB_ACTIONS and ('csh' in runner.shell):
         pytest.xfail('Fails on GitHub Actions due to inconsistent shell behavior')
     runner._set_log_directory()
+    runner.conda_env = 'test'
     script_file = runner._prepare_batch_job_script(environment_manager, 'echo hello world')
     print('script file:', script_file)
     assert 'batch_job_script' in script_file

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -177,10 +177,11 @@ def test_prepare_batch_job_script(runner, environment_manager):
     runner._set_log_directory()
     runner.conda_env = 'test'
     script_file = runner._prepare_batch_job_script(environment_manager, 'echo hello world')
-    print('script file:', script_file)
     assert 'batch_job_script' in script_file
-    assert 'hello world' in runner.run_command(f'cat {script_file}').stdout.strip()
-    assert f'{environment_manager.manager} run' in script_file
+
+    script = runner.run_command(f'cat {script_file}').stdout.strip()
+    assert 'hello world' in script
+    assert f'{environment_manager.manager} run' in script
 
 
 @requires_ssh

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -14,7 +14,6 @@ SHELLS = json.loads(os.environ.get('JUPYTER_FORWARD_TEST_SHELLS', '["bash", null
 JUPYTER_FORWARD_ENABLE_SSH_TESTS = os.environ.get('JUPYTER_FORWARD_ENABLE_SSH_TESTS') is None
 requires_ssh = pytest.mark.skipif(JUPYTER_FORWARD_ENABLE_SSH_TESTS, reason='SSH tests disabled')
 ON_GITHUB_ACTIONS = os.environ.get('GITHUB_ACTIONS') is not None
-MANAGERS = ['pixi', 'conda', 'mamba', 'micromamba']
 
 
 @contextmanager
@@ -49,7 +48,7 @@ def runner(request):
         remote.close()
 
 
-@pytest.fixture(params=MANAGERS)
+@pytest.fixture(params=sorted(environment_managers))
 def environment_manager(request):
     return environment_managers[request.param](request.param)
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -191,26 +191,6 @@ def test_parse_log_file(runner):
 
 @requires_ssh
 @pytest.mark.parametrize('runner', SHELLS, indirect=True)
-@pytest.mark.parametrize('environment', ['jupyter-forward-dev', None])
-@pytest.mark.xfail(
-    ON_GITHUB_ACTIONS, reason='Fails on GitHub Actions due to inconsistent shell behavior'
-)
-def test_conda_activate_cmd(runner, environment):
-    runner.conda_env = environment
-    cmd = runner._conda_activate_cmd()
-    assert cmd in ['source activate', 'conda activate']
-
-
-@requires_ssh
-@pytest.mark.parametrize('runner', SHELLS, indirect=True)
-def test_conda_activate_cmd_error(runner):
-    runner.conda_env = 'DOES_NOT_EXIST'
-    with pytest.raises(SystemExit):
-        runner._conda_activate_cmd()
-
-
-@requires_ssh
-@pytest.mark.parametrize('runner', SHELLS, indirect=True)
 def test_generate_redirect_cmd(runner):
     runner._set_log_directory()
     runner._set_log_file()

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -51,7 +51,7 @@ def runner(request):
 
 @pytest.fixture(params=MANAGERS)
 def environment_manager(request):
-    return environment_managers[request.param]()
+    return environment_managers[request.param](request.param)
 
 
 @requires_ssh

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -13,6 +13,7 @@ SHELLS = json.loads(os.environ.get('JUPYTER_FORWARD_TEST_SHELLS', '["bash", null
 JUPYTER_FORWARD_ENABLE_SSH_TESTS = os.environ.get('JUPYTER_FORWARD_ENABLE_SSH_TESTS') is None
 requires_ssh = pytest.mark.skipif(JUPYTER_FORWARD_ENABLE_SSH_TESTS, reason='SSH tests disabled')
 ON_GITHUB_ACTIONS = os.environ.get('GITHUB_ACTIONS') is not None
+MANAGERS = ['pixi', 'uv', 'conda', 'mamba', 'micromamba']
 
 
 @contextmanager
@@ -164,13 +165,16 @@ def test_set_logs(runner):
 
 @requires_ssh
 @pytest.mark.parametrize('runner', SHELLS, indirect=True)
-def test_prepare_batch_job_script(runner):
+@pytest.mark.parametrize('manager', MANAGERS)
+def test_prepare_batch_job_script(runner, manager):
     if ON_GITHUB_ACTIONS and ('csh' in runner.shell):
         pytest.xfail('Fails on GitHub Actions due to inconsistent shell behavior')
     runner._set_log_directory()
-    script_file = runner._prepare_batch_job_script('echo hello world')
+    script_file = runner._prepare_batch_job_script(manager, 'echo hello world')
+    print('script file:', script_file)
     assert 'batch_job_script' in script_file
     assert 'hello world' in runner.run_command(f'cat {script_file}').stdout.strip()
+    assert f'{manager} run' in script_file
 
 
 @requires_ssh


### PR DESCRIPTION
## Change Summary

This adds the `--environment-manager` and `--environment-manager-path` cli options, as well as replacing the `activate` step with the `run` subcommand.

No tests, yet.

## Related issue number

- [x] closes #257, closes #248

## Checklist

- [ ] Unit tests for the changes exist
- [x] Tests pass on CI
- [ ] Documentation reflects the changes where applicable
