### PR TITLE
test python 3.13 and 3.14, and drop 3.10

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@v6
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,9 +10,10 @@
         "Natural Language :: English",
         "Operating System :: OS Independent",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
+        "Programming Language :: Python :: 3.14",
         "Topic :: Scientific/Engineering",
     ]
     description = "Jupyter Lab Port Forwarding Utility"


### PR DESCRIPTION
Python 3.10 is reaching its end-of-life in ~3 months, while python 3.13 and 3.14 have been out for a while. Thus, I think the tested range should be to 3.11 to 3.14 (or 3.12 to 3.14, if you want to follow SPEC0).